### PR TITLE
Removing dynamic egress code as it's functionality has been superseded

### DIFF
--- a/internal_policy_client.go
+++ b/internal_policy_client.go
@@ -11,7 +11,7 @@ import (
 
 //go:generate counterfeiter -o fakes/internal_policy_client.go --fake-name InternalPolicyClient . InternalPolicyClient
 type InternalPolicyClient interface {
-	GetPolicies() ([]*Policy, []*EgressPolicy, error)
+	GetPolicies() ([]*Policy, error)
 	GetSecurityGroupsForSpace(spaceGuids []string) ([]*SecurityGroup, error)
 }
 
@@ -45,31 +45,29 @@ func NewInternal(logger lager.Logger, httpClient json_client.HttpClient, baseURL
 	}
 }
 
-func (c *InternalClient) GetPolicies() ([]*Policy, []*EgressPolicy, error) {
+func (c *InternalClient) GetPolicies() ([]*Policy, error) {
 	var policies struct {
-		Policies       []*Policy       `json:"policies"`
-		EgressPolicies []*EgressPolicy `json:"egress_policies"`
+		Policies []*Policy `json:"policies"`
 	}
 	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies", nil, &policies, "")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return policies.Policies, policies.EgressPolicies, nil
+	return policies.Policies, nil
 }
 
-func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, []EgressPolicy, error) {
+func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, error) {
 	var policies struct {
-		Policies       []Policy       `json:"policies"`
-		EgressPolicies []EgressPolicy `json:"egress_policies"`
+		Policies []Policy `json:"policies"`
 	}
 	if len(ids) == 0 {
-		return nil, nil, errors.New("ids cannot be empty")
+		return nil, errors.New("ids cannot be empty")
 	}
 	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies?id="+strings.Join(ids, ","), nil, &policies, "")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return policies.Policies, policies.EgressPolicies, nil
+	return policies.Policies, nil
 }
 
 func (c *InternalClient) GetSecurityGroupsForSpace(spaceGuids ...string) ([]SecurityGroup, error) {

--- a/internal_policy_client_test.go
+++ b/internal_policy_client_test.go
@@ -102,7 +102,7 @@ var _ = Describe("InternalClient", func() {
 		})
 
 		It("does the right json http client request", func() {
-			policies, egressPolicies, err := client.GetPolicies()
+			policies, err := client.GetPolicies()
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(jsonClient.DoCallCount()).To(Equal(1))
@@ -128,32 +128,6 @@ var _ = Describe("InternalClient", func() {
 				},
 			},
 			))
-			Expect(egressPolicies).To(Equal([]*policy_client.EgressPolicy{
-				{
-					Source: &policy_client.EgressSource{
-						ID: "some-other-app-guid",
-					},
-					Destination: &policy_client.EgressDestination{
-						Protocol: "tcp",
-						IPRanges: []policy_client.IPRange{
-							{Start: "1.2.3.4", End: "1.2.3.5"},
-						},
-					},
-				},
-				{
-					Source: &policy_client.EgressSource{
-						ID: "some-other-app-guid",
-					},
-					Destination: &policy_client.EgressDestination{
-						Protocol: "icmp",
-						ICMPType: 8,
-						ICMPCode: 4,
-						IPRanges: []policy_client.IPRange{
-							{Start: "1.2.3.4", End: "1.2.3.5"},
-						},
-					},
-				},
-			}))
 			Expect(token).To(BeEmpty())
 		})
 
@@ -162,7 +136,7 @@ var _ = Describe("InternalClient", func() {
 				jsonClient.DoReturns(errors.New("banana"))
 			})
 			It("returns the error", func() {
-				_, _, err := client.GetPolicies()
+				_, err := client.GetPolicies()
 				Expect(err).To(MatchError("banana"))
 			})
 		})
@@ -178,7 +152,7 @@ var _ = Describe("InternalClient", func() {
 		})
 
 		It("does the right json http client request", func() {
-			policies, egressPolicies, err := client.GetPoliciesByID("some-app-guid", "some-other-app-guid")
+			policies, err := client.GetPoliciesByID("some-app-guid", "some-other-app-guid")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(jsonClient.DoCallCount()).To(Equal(1))
@@ -204,32 +178,6 @@ var _ = Describe("InternalClient", func() {
 				},
 			},
 			))
-			Expect(egressPolicies).To(Equal([]policy_client.EgressPolicy{
-				{
-					Source: &policy_client.EgressSource{
-						ID: "some-other-app-guid",
-					},
-					Destination: &policy_client.EgressDestination{
-						Protocol: "tcp",
-						IPRanges: []policy_client.IPRange{
-							{Start: "1.2.3.4", End: "1.2.3.5"},
-						},
-					},
-				},
-				{
-					Source: &policy_client.EgressSource{
-						ID: "some-other-app-guid",
-					},
-					Destination: &policy_client.EgressDestination{
-						Protocol: "icmp",
-						ICMPType: 8,
-						ICMPCode: 4,
-						IPRanges: []policy_client.IPRange{
-							{Start: "1.2.3.4", End: "1.2.3.5"},
-						},
-					},
-				},
-			}))
 
 			Expect(token).To(BeEmpty())
 		})
@@ -239,7 +187,7 @@ var _ = Describe("InternalClient", func() {
 				jsonClient.DoReturns(errors.New("banana"))
 			})
 			It("returns the error", func() {
-				_, _, err := client.GetPoliciesByID("foo")
+				_, err := client.GetPoliciesByID("foo")
 				Expect(err).To(MatchError("banana"))
 			})
 		})
@@ -247,10 +195,9 @@ var _ = Describe("InternalClient", func() {
 		Context("when ids is empty", func() {
 			BeforeEach(func() {})
 			It("returns an error and does not call the json http client", func() {
-				policies, egressPolicies, err := client.GetPoliciesByID()
+				policies, err := client.GetPoliciesByID()
 				Expect(err).To(MatchError("ids cannot be empty"))
 				Expect(policies).To(BeNil())
-				Expect(egressPolicies).To(BeNil())
 				Expect(jsonClient.DoCallCount()).To(Equal(0))
 			})
 		})
@@ -343,7 +290,7 @@ var _ = Describe("InternalClient", func() {
 				jsonClient.DoReturns(errors.New("banana"))
 			})
 			It("returns the error", func() {
-				_, _, err := client.GetPoliciesByID("foo")
+				_, err := client.GetPoliciesByID("foo")
 				Expect(err).To(MatchError("banana"))
 			})
 		})


### PR DESCRIPTION
Dynamic Egress is no longer being used and is being removed from the Cloud Foundry code bases. Dynamic ASG's are the feature that have replaced it and should be used instead.