### PR TITLE
Add GetPoliciesLastUpdated method for policies_last_updated endpoint

### DIFF
--- a/internal_policy_client.go
+++ b/internal_policy_client.go
@@ -56,6 +56,15 @@ func (c *InternalClient) GetPolicies() ([]*Policy, error) {
 	return policies.Policies, nil
 }
 
+func (c *InternalClient) GetPoliciesLastUpdated() (int, error) {
+	var lastUpdatedTimestamp int
+	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies_last_updated", nil, &lastUpdatedTimestamp, "")
+	if err != nil {
+		return 0, err
+	}
+	return lastUpdatedTimestamp, nil
+}
+
 func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, error) {
 	var policies struct {
 		Policies []Policy `json:"policies"`

--- a/internal_policy_client_test.go
+++ b/internal_policy_client_test.go
@@ -142,6 +142,40 @@ var _ = Describe("InternalClient", func() {
 		})
 	})
 
+	Describe("GetPoliciesLastUpdated", func() {
+		BeforeEach(func() {
+			jsonClient.DoStub = func(method, route string, reqData, respData interface{}, token string) error {
+				respBytes := []byte("12345")
+				json.Unmarshal(respBytes, respData)
+				return nil
+			}
+		})
+
+		It("does the right json http client request", func() {
+			lastUpdated, err := client.GetPoliciesLastUpdated()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(jsonClient.DoCallCount()).To(Equal(1))
+			method, route, reqData, _, token := jsonClient.DoArgsForCall(0)
+			Expect(method).To(Equal("GET"))
+			Expect(route).To(Equal("/networking/v1/internal/policies_last_updated"))
+			Expect(reqData).To(BeNil())
+
+			Expect(lastUpdated).To(Equal(12345))
+			Expect(token).To(BeEmpty())
+		})
+
+		Context("when the json client fails", func() {
+			BeforeEach(func() {
+				jsonClient.DoReturns(errors.New("banana"))
+			})
+			It("returns the error", func() {
+				_, err := client.GetPoliciesLastUpdated()
+				Expect(err).To(MatchError("banana"))
+			})
+		})
+	})
+
 	Describe("GetPoliciesByID", func() {
 		BeforeEach(func() {
 			jsonClient.DoStub = func(method, route string, reqData, respData interface{}, token string) error {


### PR DESCRIPTION
This PR accompanies [policy server PR that adds policies_last_updated endpoint](https://github.com/cloudfoundry/cf-networking-release/pull/231)